### PR TITLE
Nogc nothrow patch, and dub config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.dub/
+__test__source
+dub.userprefs
+libffmpeg-d.a

--- a/dub.json
+++ b/dub.json
@@ -1,56 +1,56 @@
 {
-	"name": "ffmpeg-d",
-	"description": "FFmpeg Bindings",
-	"copyright": "Copyright © 2013",
-	"license": "LGPL-2.1",
-	"authors": [
-		"Sumit Raja",
-		"donglei",
-		"Relja Ljubobratovic"
-	],
+    "name": "ffmpeg-d",
+    "description": "FFmpeg Bindings",
+    "copyright": "Copyright © 2013",
+    "license": "LGPL-2.1",
+    "authors": [
+        "Sumit Raja",
+        "donglei",
+        "Relja Ljubobratovic"
+    ],
 
-	"targetType": "sourceLibrary",
-	"platforms": ["Windows", "Posix"],
-	"sourcePaths": ["source/ffmpeg"],
-	"importPaths": ["source/ffmpeg"],
+    "targetType": "sourceLibrary",
+    "platforms": ["Windows", "Posix"],
+    "sourcePaths": ["source/ffmpeg"],
+    "importPaths": ["source/ffmpeg"],
 
-	"libs": [
-		"avcodec",
-		"avformat",
-		"avutil",
-		"avfilter",
-		"avdevice",
-		"swscale"
-	],
+    "libs": [
+        "avcodec",
+        "avformat",
+        "avutil",
+        "avfilter",
+        "avdevice",
+        "swscale"
+    ],
 
-	"configurations": [
-		{
-			"name": "posix-test-executable",
-			"mainSourceFile": "source/app.d",
-			"targetType": "executable",
-			"platforms": ["Posix"],
-			"libs": [
-				"avcodec",
-				"avformat",
-				"avutil",
-				"avfilter",
-				"avdevice",
-				"swscale"
-			]
-		},
-		{
-			"name": "windows-test-executable",
-			"mainSourceFile": "source/app.d",
-			"targetType": "executable",
-			"platforms": ["Windows"],
-			"libs": [
-				"avcodec",
-				"avformat",
-				"avutil",
-				"avfilter",
-				"avdevice",
-				"swscale"
-			]
-		}
-	]
+    "configurations": [
+        {
+            "name": "posix-test-executable",
+            "mainSourceFile": "source/app.d",
+            "targetType": "executable",
+            "platforms": ["Posix"],
+            "libs": [
+                "avcodec",
+                "avformat",
+                "avutil",
+                "avfilter",
+                "avdevice",
+                "swscale"
+            ]
+        },
+        {
+            "name": "windows-test-executable",
+            "mainSourceFile": "source/app.d",
+            "targetType": "executable",
+            "platforms": ["Windows"],
+            "libs": [
+                "avcodec",
+                "avformat",
+                "avutil",
+                "avfilter",
+                "avdevice",
+                "swscale"
+            ]
+        }
+    ]
 }

--- a/dub.json
+++ b/dub.json
@@ -9,10 +9,7 @@
         "Relja Ljubobratovic"
     ],
 
-    "targetType": "sourceLibrary",
     "platforms": ["Windows", "Posix"],
-    "sourcePaths": ["source/ffmpeg"],
-    "importPaths": ["source/ffmpeg"],
 
     "libs": [
         "avcodec",
@@ -23,34 +20,21 @@
         "swscale"
     ],
 
+    "buildTypes": {
+        "unittest": {
+            "buildOptions": ["unittests"],
+            "sourcePaths": ["./source/ffmpeg", "./test/"]
+        }
+    },
+
     "configurations": [
         {
-            "name": "posix-test-executable",
-            "mainSourceFile": "source/app.d",
-            "targetType": "executable",
-            "platforms": ["Posix"],
-            "libs": [
-                "avcodec",
-                "avformat",
-                "avutil",
-                "avfilter",
-                "avdevice",
-                "swscale"
-            ]
+            "name": "source",
+            "targetType": "sourceLibrary"
         },
         {
-            "name": "windows-test-executable",
-            "mainSourceFile": "source/app.d",
-            "targetType": "executable",
-            "platforms": ["Windows"],
-            "libs": [
-                "avcodec",
-                "avformat",
-                "avutil",
-                "avfilter",
-                "avdevice",
-                "swscale"
-            ]
+            "name": "static",
+            "targetType": "staticLibrary"
         }
     ]
 }

--- a/source/ffmpeg/libavcodec/avcodec.d
+++ b/source/ffmpeg/libavcodec/avcodec.d
@@ -37,7 +37,7 @@ import ffmpeg.libavutil.rational; //#include "libavutil/rational.h"
 
 import ffmpeg.libavcodec.avcodec_version; //#include "version.h"
 
-extern(C):
+@nogc nothrow extern(C):
 /**
  * @defgroup libavc Encoding/Decoding Library
  * @{

--- a/source/ffmpeg/libavdevice/avdevice.d
+++ b/source/ffmpeg/libavdevice/avdevice.d
@@ -52,7 +52,7 @@ import ffmpeg.libavformat.avformat;
 import ffmpeg.libavcodec.avcodec;
 import ffmpeg.libavdevice.avdevice_version;
 
-extern(C):
+@nogc nothrow extern(C):
 /**
  * Return the LIBAVDEVICE_VERSION_INT constant.
  */
@@ -420,7 +420,7 @@ struct AVDeviceCapabilitiesQuery {
 /**
  * AVOption table used by devices to implement device capabilities API. Should not be used by a user.
  */
-extern(C) const AVOption []av_device_capabilities;
+const AVOption []av_device_capabilities;
 
 /**
  * Initialize capabilities probing API based on AVOption API.

--- a/source/ffmpeg/libavfilter/avfilter.d
+++ b/source/ffmpeg/libavfilter/avfilter.d
@@ -42,7 +42,7 @@ import ffmpeg.libavfilter.internal;
 import ffmpeg.libavfilter.formats;
 import ffmpeg.libavfilter.avfilter_version;
 
-extern(C):
+@nogc nothrow extern(C):
 /**
 * Return the LIBAVFILTER_VERSION_INT constant.
 */

--- a/source/ffmpeg/libavfilter/formats.d
+++ b/source/ffmpeg/libavfilter/formats.d
@@ -21,6 +21,7 @@ module ffmpeg.libavfilter.formats;
 import std.stdint;
 import ffmpeg.libavfilter.avfilter;
 
+@nogc nothrow extern(C):
 /**
  * A list of supported formats for one end of a filter link. This is used
  * during the format negotiation process to try to pick the best format to

--- a/source/ffmpeg/libavfilter/internal.d
+++ b/source/ffmpeg/libavfilter/internal.d
@@ -18,7 +18,7 @@
 
 module ffmpeg.libavfilter.internal;
 
-extern(C):
+@nogc nothrow extern(C):
 /**
  * @file
  * internal API functions

--- a/source/ffmpeg/libavformat/avformat.d
+++ b/source/ffmpeg/libavformat/avformat.d
@@ -263,7 +263,7 @@ import ffmpeg.libavformat.avio;
 import ffmpeg.libavformat.avformat_version;
 import ffmpeg.libavdevice.avdevice;
 
-extern(C):
+@nogc nothrow extern(C):
 /**
  * @defgroup metadata_api Public Metadata API
  * @{

--- a/source/ffmpeg/libavformat/avio.d
+++ b/source/ffmpeg/libavformat/avio.d
@@ -23,7 +23,7 @@ import std.stdio;
 import ffmpeg.libavutil.avutil;
 import ffmpeg.libavformat.avformat_version;
 
-extern(C):
+@nogc nothrow extern(C):
 /**
  * @file
  * @ingroup lavf_io

--- a/source/ffmpeg/libavutil/avutil.d
+++ b/source/ffmpeg/libavutil/avutil.d
@@ -36,7 +36,32 @@ public import ffmpeg.libavutil.mathematics;
 public import ffmpeg.libavutil.channel_layout;
 public import ffmpeg.libavutil.avutil_version;
 
-extern(C): 
+  
+/**
+ * Fill the provided buffer with a string containing a timestamp time
+ * representation.
+ *
+ * @param buf a buffer with size in bytes of at least AV_TS_MAX_STRING_SIZE
+ * @param ts the timestamp to represent
+ * @param tb the timebase of the timestamp
+ * @return the buffer in input
+ */
+string av_ts_make_time_string(int64_t ts, AVRational tb)
+{
+  import std.format; 
+  import std.array;
+  if (ts == AV_NOPTS_VALUE) {
+    return "No Value";
+  } else {
+    auto toTs = av_q2d(tb) * ts;
+    auto writer = appender!string(); 
+    formattedWrite(writer, "%.6g", toTs);
+    return writer.data;
+  }
+}
+
+@nogc nothrow extern(C): 
+
 /*
  * @mainpage
  *
@@ -240,29 +265,6 @@ enum AVPictureType {
  */
 char av_get_picture_type_char(AVPictureType pict_type);
 // end avutil.h
-  
-/**
- * Fill the provided buffer with a string containing a timestamp time
- * representation.
- *
- * @param buf a buffer with size in bytes of at least AV_TS_MAX_STRING_SIZE
- * @param ts the timestamp to represent
- * @param tb the timebase of the timestamp
- * @return the buffer in input
- */
-string av_ts_make_time_string(int64_t ts, AVRational tb)
-{
-  import std.format; 
-  import std.array;
-  if (ts == AV_NOPTS_VALUE) {
-    return "No Value";
-  } else {
-    auto toTs = av_q2d(tb) * ts;
-    auto writer = appender!string(); 
-    formattedWrite(writer, "%.6g", toTs);
-    return writer.data;
-  }
-}
 
 /**
  * Return x default pointer in case p is NULL.

--- a/source/ffmpeg/libavutil/buffer.d
+++ b/source/ffmpeg/libavutil/buffer.d
@@ -20,7 +20,7 @@ module ffmpeg.libavutil.buffer;
 
 import std.stdint;
 
-extern(C):
+@nogc nothrow extern(C):
 
 /**
  * @file

--- a/source/ffmpeg/libavutil/channel_layout.d
+++ b/source/ffmpeg/libavutil/channel_layout.d
@@ -25,7 +25,7 @@
 module ffmpeg.libavutil.channel_layout;
 import std.stdint;
 
-extern(C):
+@nogc nothrow extern(C):
 /**
  * @file
  * audio channel layout utility functions

--- a/source/ffmpeg/libavutil/common.d
+++ b/source/ffmpeg/libavutil/common.d
@@ -22,6 +22,8 @@ module ffmpeg.libavutil.common;
 import std.stdint;
 import ffmpeg.libavutil.avutil_version;
 
+@nogc nothrow:
+
 template MKBETAG(int a, int b, int c, int d) {
   const int MKBETAG = ((d) | ((c) << 8) | ((b) << 16) | (cast(uint)(a) << 24));
 }

--- a/source/ffmpeg/libavutil/dict.d
+++ b/source/ffmpeg/libavutil/dict.d
@@ -27,9 +27,10 @@
  *  It is recommended that new code uses our tree container from tree.c/h
  *  where applicable, which uses AVL trees to achieve O(log n) performance.
  */
-
 module ffmpeg.libavutil.dict;
-extern(C):
+
+@nogc nothrow extern(C):
+
 /**
  * @addtogroup lavu_dict AVDictionary
  * @ingroup lavu_data

--- a/source/ffmpeg/libavutil/error.d
+++ b/source/ffmpeg/libavutil/error.d
@@ -26,7 +26,8 @@ import core.stdc.errno;
 import core.stdc.stddef;
 import ffmpeg.libavutil.common;
 
-extern(C):
+@nogc nothrow extern(C):
+
 /**
  * @addtogroup lavu_error
  *

--- a/source/ffmpeg/libavutil/frame.d
+++ b/source/ffmpeg/libavutil/frame.d
@@ -37,7 +37,7 @@ import ffmpeg.libavutil.samplefmt; //#include "samplefmt.h"
 import ffmpeg.libavutil.pixfmt; //#include "pixfmt.h"
 import ffmpeg.libavutil.avutil_version; //#include "version.h"
 
-extern (C):
+@nogc nothrow extern(C):
 /**
  * @defgroup lavu_frame AVFrame
  * @ingroup lavu_data

--- a/source/ffmpeg/libavutil/intfloat.d
+++ b/source/ffmpeg/libavutil/intfloat.d
@@ -19,7 +19,9 @@
  */
 module ffmpeg.libavutil.intfloat;
 import std.stdint;
-import std.conv;
+import std.math : floor;
+
+@nogc nothrow extern(C):
 
 union av_intfloat32 {
     uint32_t i;
@@ -31,13 +33,12 @@ union av_intfloat64 {
     double   f;
 };
 
-extern(C):
 /**
  * Reinterpret a 32-bit integer as a float.
  */
 static float av_int2float(uint32_t i)
 {
-    return to!float(i);
+    return float(i);
 }
 
 /**
@@ -45,7 +46,7 @@ static float av_int2float(uint32_t i)
  */
 static uint32_t av_float2int(float f)
 {
-    return to!int(f);
+    return cast(uint32_t)floor(f);
 }
 
 /**
@@ -53,7 +54,7 @@ static uint32_t av_float2int(float f)
  */
 static double av_int2double(uint64_t i)
 {
-    return to!double(i);
+    return double(i);
 }
 
 /**
@@ -61,6 +62,6 @@ static double av_int2double(uint64_t i)
  */
 static uint64_t av_double2int(double f)
 {
-    return to!int(f);
+    return cast(uint64_t)floor(f);
 }
 

--- a/source/ffmpeg/libavutil/intfloat_readwrite.d
+++ b/source/ffmpeg/libavutil/intfloat_readwrite.d
@@ -20,7 +20,8 @@
 module ffmpeg.libavutil.intfloat_readwrite;
 import std.stdint;
 
-extern(C) 
+@nogc nothrow extern(C): 
+
 /* IEEE 80 bits extended float */
 struct AVExtFloat {
       uint8_t [2]exponent;

--- a/source/ffmpeg/libavutil/log.d
+++ b/source/ffmpeg/libavutil/log.d
@@ -22,7 +22,7 @@ import std.stdint;
 import core.vararg;
 import ffmpeg.libavutil.opt;
 
-extern(C):
+@nogc nothrow extern(C):
 
 enum AVClassCategory {
     AV_CLASS_CATEGORY_NA = 0,

--- a/source/ffmpeg/libavutil/mathematics.d
+++ b/source/ffmpeg/libavutil/mathematics.d
@@ -33,9 +33,9 @@ enum M_SQRT2      =  1.41421356237309504880; /* sqrt(2) */
 enum NAN          =  av_int2float(0x7fc00000);
 enum INFINITY     =  av_int2float(0x7f800000);
 
+@nogc nothrow extern(C):
 
-extern (C):
- /**
+/**
  * @addtogroup lavu_math
  * @{
  */

--- a/source/ffmpeg/libavutil/mem.d
+++ b/source/ffmpeg/libavutil/mem.d
@@ -30,10 +30,11 @@ module ffmpeg.libavutil.mem;
 import std.stdint;
 import core.stdc.errno;
 import ffmpeg.libavutil.error;
-extern(C):
 /*#include "attributes.h"
 #include "error.h"
 #include "avutil.h"*/
+
+@nogc nothrow extern(C):
 
 /**
  * @addtogroup lavu_mem

--- a/source/ffmpeg/libavutil/opt.d
+++ b/source/ffmpeg/libavutil/opt.d
@@ -29,7 +29,8 @@ import ffmpeg.libavutil.pixfmt;
 import ffmpeg.libavutil.samplefmt;
 import ffmpeg.libavutil.dict;
 
-extern(C):
+@nogc nothrow extern(C):
+
 /**
  * @defgroup avoptions AVOptions
  * @ingroup lavu_data

--- a/source/ffmpeg/libavutil/pixfmt.d
+++ b/source/ffmpeg/libavutil/pixfmt.d
@@ -30,7 +30,8 @@ import ffmpeg.libavutil.common;
  *
  */
 
-extern(C):
+@nogc nothrow extern(C):
+
 enum AVPALETTE_SIZE = 1024;
 enum AVPALETTE_COUNT = 256;
 

--- a/source/ffmpeg/libavutil/rational.d
+++ b/source/ffmpeg/libavutil/rational.d
@@ -21,7 +21,8 @@
 module ffmpeg.libavutil.rational;
 import std.stdint;
 
-extern(C):
+@nogc nothrow extern(C):
+
 /**
  * @addtogroup lavu_math
  * @{

--- a/source/ffmpeg/libavutil/samplefmt.d
+++ b/source/ffmpeg/libavutil/samplefmt.d
@@ -16,9 +16,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-module ffmpeg.libavutil.samplefmt;
-import ffmpeg.libavutil.avutil_version;
-
 /**
  * Audio Sample Formats
  *
@@ -41,8 +38,11 @@ import ffmpeg.libavutil.avutil_version;
  * plane is used, and samples for each channel are interleaved. In this case,
  * linesize is the buffer size, in bytes, for the 1 plane.
  */
+module ffmpeg.libavutil.samplefmt;
 
-extern(C):
+import ffmpeg.libavutil.avutil_version;
+
+@nogc nothrow extern(C):
 
 enum AVSampleFormat {
     AV_SAMPLE_FMT_NONE = -1,

--- a/source/ffmpeg/libswscale/rgb2rgb.d
+++ b/source/ffmpeg/libswscale/rgb2rgb.d
@@ -2,10 +2,8 @@ module ffmpeg.libswscale.rgb2rgb;
 
 import ffmpeg.libavutil.avutil;
 import std.stdint;
-extern(C):
 
-
-
+@nogc nothrow extern(C):
 
 void rgb64tobgr48_nobswap(const uint8_t *src, uint8_t *dst, int src_size);
 void   rgb64tobgr48_bswap(const uint8_t *src, uint8_t *dst, int src_size);

--- a/source/ffmpeg/libswscale/swscale.d
+++ b/source/ffmpeg/libswscale/swscale.d
@@ -2,7 +2,8 @@ module ffmpeg.libswscale.swscale;
 import std.stdint;
 import ffmpeg.libavutil.avutil;
 
-extern(C):
+@nogc nothrow extern(C):
+
 /**
 * @defgroup libsws Color conversion and scaling
 * @{

--- a/source/ffmpeg/libswscale/swscale_internal.d
+++ b/source/ffmpeg/libswscale/swscale_internal.d
@@ -3,7 +3,8 @@ module ffmpeg.libswscale.swscale_internal;
 import ffmpeg.libswscale.swscale_version;
 import ffmpeg.libavutil.avutil;
 
-extern(C):
+@nogc nothrow extern(C):
+
 enum YUVRGB_TABLE_HEADROOM = 256;
 
 //enum MAX_FILTER_SIZE = SWS_MAX_FILTER_SIZE;

--- a/test/test.d
+++ b/test/test.d
@@ -18,6 +18,7 @@ unittest {
     avformat_network_init();
     avcodec_register_all();
     avfilter_register_all();
+
     writeln("AVCodec binding version: " ~ to!string(LIBAVCODEC_VERSION_INT));
     writeln("AVCodec version: " ~ to!string(avcodec_version()));
     writeln("AVCodec config: " ~ to!string(avcodec_configuration()));
@@ -32,8 +33,5 @@ unittest {
     writeln("AVFilter version: " ~ to!string(avfilter_version()));
     writeln("SWScale binding version: " ~ to!string(LIBSWSCALE_VERSION_INT));
     writeln("SWScale version: " ~ to!string(swscale_version()));
-
 }
 
-void main() {
-}


### PR DESCRIPTION
Working on #6 and #7. @9il, should you see anything wrong, please tell me. All examples in DCV that are using ffmpegd modules work fine with these changes, hope there'll be no breakage in other projects as well.

Note: there are still some modules with GC - version listing modules, because of strings. But since those are isolated from most of the library, I'd say we're ok.

Also, since I've been changing the dub.json, I've moved source/app.d to test/test.d, with only unittest block (removed main). Even though this is not formal testing, having it as an executable didn't make much sense imho.
