### PR TITLE
Corrected libpostproc being linked by default

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -9,15 +9,12 @@
         "Relja Ljubobratovic"
     ],
 
-    "platforms": ["Windows", "Posix"],
-
     "libs": [
         "avcodec",
         "avdevice",
         "avfilter",
         "avformat",
         "avutil",
-        "postproc",
         "swresample",
         "swscale"
     ],
@@ -32,11 +29,23 @@
     "configurations": [
         {
             "name": "source",
-            "targetType": "sourceLibrary"
+            "targetType": "sourceLibrary",
+            "excludedSourceFiles": ["source/ffmpeg/libpostproc/*"]
         },
         {
             "name": "static",
-            "targetType": "staticLibrary"
+            "targetType": "staticLibrary",
+            "excludedSourceFiles": ["source/ffmpeg/libpostproc/*"]
+        },
+        {
+            "name": "source-GPL",
+            "targetType": "sourceLibrary",
+            "libs": ["postproc"]
+        },
+        {
+            "name": "static-GPL",
+            "targetType": "staticLibrary",
+            "libs": ["postproc"]
         },
         {
             "name": "remux_example",


### PR DESCRIPTION
The postproc library is automatically included in the list of "libs" in your project's dub.json. However, [using it requires the GPL license](https://ffmpeg.org/doxygen/4.1/postprocess_8h_source.html) (rather than LGPL) and it is [a mostly useless legacy library](https://stackoverflow.com/a/61018028).
In future versions, this should be opt-in so that people aren't unknowingly breaking the licensing conditions of a library they probably aren't even using.

P.S. I also removed the `"platforms"` key from the root of the dub.json because [it's only meant to be used in configurations](https://dub.pm/package-format-json.html#configuration-settings) to indicate that they're platform-specific, so it produced a warning when building the library:
```
 Warning ffmpeg-d/dub.json(11:4): platforms: Key is not a
valid member of this section. There are 53 valid keys: name,
description, homepage, authors, copyright, license,
toolchainRequirements, configurations, buildTypes,
-ddoxFilterArgs, -ddoxTool, subPackages, version, dependencies,
systemDependencies, targetType, targetPath, targetName,
workingDirectory, mainSourceFile, subConfigurations, dflags,
lflags, libs, sourceFiles, sourcePaths, excludedSourceFiles,
injectSourceFiles, copyFiles, extraDependencyFiles, versions,
debugVersions, versionFilters, debugVersionFilters,
importPaths, stringImportPaths, preGenerateCommands,
postGenerateCommands, preBuildCommands, postBuildCommands,
preRunCommands, postRunCommands, environments,
buildEnvironments, runEnvironments, preGenerateEnvironments,
postGenerateEnvironments, preBuildEnvironments,
postBuildEnvironments, preRunEnvironments,
postRunEnvironments, buildRequirements, buildOptions
```